### PR TITLE
Components > 遷移後にハンバーガーメニューを閉じる

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,18 +1,12 @@
 import {
   AppShell,
   Burger,
-  Group,
   Header,
   MediaQuery,
   Navbar,
   Text,
-  ThemeIcon,
 } from "@mantine/core";
-import {
-  IconCalendarEvent,
-  IconPinned,
-  IconTruckDelivery,
-} from "@tabler/icons";
+import { IconPinned } from "@tabler/icons";
 import { FC, PropsWithChildren, useState } from "react";
 import { NavbarLinks } from "./NavbarLinks";
 
@@ -36,7 +30,7 @@ export const Layout: FC<PropsWithChildren> = (props) => {
           })}
         >
           <Navbar.Section grow mt="sm">
-            <NavbarLinks />
+            <NavbarLinks setOpened={setOpened} />
           </Navbar.Section>
         </Navbar>
       }

--- a/src/components/NavbarLinks.tsx
+++ b/src/components/NavbarLinks.tsx
@@ -13,6 +13,11 @@ type NavbarLinkProps = {
   color: string;
   label: string;
   href: string;
+  setOpened: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+type NavbarLinksProps = {
+  setOpened: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const NavbarLink: FC<NavbarLinkProps> = ({
@@ -20,6 +25,7 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
   color,
   label,
   href,
+  setOpened,
 }) => {
   return (
     <Link to={href} style={{ textDecoration: "none" }}>
@@ -34,6 +40,7 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
             backgroundColor: theme.colors.gray[0],
           },
         })}
+        onClick={() => setOpened(false)}
       >
         <Group>
           <ThemeIcon color={color} variant="light">
@@ -73,11 +80,11 @@ const linkData = [
   },
 ];
 
-export const NavbarLinks = () => {
+export const NavbarLinks = ({ setOpened }: NavbarLinksProps) => {
   return (
     <div>
       {linkData.map((link) => (
-        <NavbarLink {...link} key={link.label} />
+        <NavbarLink {...link} key={link.label} setOpened={setOpened} />
       ))}
     </div>
   );


### PR DESCRIPTION
## issue
- #12 

## なぜやるのか
- ハンバーガーメニューを開き、リンクをクリックして遷移した後、ハンバーガーメニューが自動的に閉じられず、UXが悪い

## なにをやったのか
- ハンバーガーメニューの開閉を管理する状態のセット関数をNavbarLinkに渡し、それをonClickで呼び出す