### PR TITLE
Group > グループ情報を見られるように

### DIFF
--- a/src/components/NavbarLinks.tsx
+++ b/src/components/NavbarLinks.tsx
@@ -4,6 +4,7 @@ import {
   IconHome,
   IconTruck,
   IconUser,
+  IconUsers,
 } from "@tabler/icons";
 import { FC, ReactNode } from "react";
 import { Link } from "react-router-dom";
@@ -73,9 +74,15 @@ const linkData = [
   //   href: "/app/parcel",
   // },
   {
+    icon: <IconUsers size={16} />,
+    color: "green",
+    label: "グループ情報",
+    href: "/app/group/information",
+  },
+  {
     icon: <IconUser size={16} />,
     color: "violet",
-    label: "ユーザー",
+    label: "ユーザー情報",
     href: "/app/user",
   },
 ];

--- a/src/features/group/components/GroupInformation.tsx
+++ b/src/features/group/components/GroupInformation.tsx
@@ -12,37 +12,11 @@ import {
   CopyButton,
   ActionIcon,
 } from "@mantine/core";
-import { FirebaseContext, UserContext } from "../../../contexts";
-import { useContext, useState, useEffect } from "react";
-
-import { findGroup } from "../api/find-group";
-import { GroupType } from "../types";
-import { showNotification } from "@mantine/notifications";
 import { IconClipboard, IconClipboardCheck } from "@tabler/icons";
+import useGroupInformation from "../hooks/useGroupInformation";
 
 const GroupInformation = () => {
-  const { user } = useContext(UserContext);
-  const { db } = useContext(FirebaseContext);
-  const [groupData, setGroupData] = useState<GroupType | null>();
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    (async () => {
-      setIsLoading(true);
-      if (db && user && user.groupId) {
-        try {
-          const newGroupData = await findGroup(db, user.groupId);
-          setGroupData(newGroupData);
-        } catch (error) {
-          showNotification({
-            message: "グループ情報の取得に失敗しました",
-            color: "red",
-          });
-        }
-      }
-      setIsLoading(false);
-    })();
-  }, []);
+  const { groupData, isLoading } = useGroupInformation();
 
   return (
     <Container size={400} my={40}>

--- a/src/features/group/components/GroupInformation.tsx
+++ b/src/features/group/components/GroupInformation.tsx
@@ -1,0 +1,105 @@
+import {
+  Avatar,
+  Container,
+  Title,
+  Stack,
+  Text,
+  Group,
+  Card,
+  Center,
+  Loader,
+  Divider,
+  CopyButton,
+  ActionIcon,
+} from "@mantine/core";
+import { FirebaseContext, UserContext } from "../../../contexts";
+import { useContext, useState, useEffect } from "react";
+
+import { findGroup } from "../api/find-group";
+import { GroupType } from "../types";
+import { showNotification } from "@mantine/notifications";
+import { IconClipboard, IconClipboardCheck } from "@tabler/icons";
+
+const GroupInformation = () => {
+  const { user } = useContext(UserContext);
+  const { db } = useContext(FirebaseContext);
+  const [groupData, setGroupData] = useState<GroupType | null>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      if (db && user && user.groupId) {
+        try {
+          const newGroupData = await findGroup(db, user.groupId);
+          setGroupData(newGroupData);
+        } catch (error) {
+          showNotification({
+            message: "グループ情報の取得に失敗しました",
+            color: "red",
+          });
+        }
+      }
+      setIsLoading(false);
+    })();
+  }, []);
+
+  return (
+    <Container size={400} my={40}>
+      <Title order={2} align="center" color="cyan.5" mb="lg">
+        グループ情報
+      </Title>
+      <Stack>
+        {isLoading && (
+          <Center>
+            <Loader />
+          </Center>
+        )}
+        {groupData ? (
+          <>
+            <Card>
+              <Text size="xs" color="gray">
+                グループ名
+              </Text>
+              <Text size="xl">{groupData.groupName}</Text>
+              <Divider my="md" label="所属ユーザー" color="gray" />
+              <Stack>
+                {groupData.users.map((user) => {
+                  if (user.displayName && user.displayName) {
+                    return (
+                      <Group>
+                        <Avatar
+                          color={user.avatarColor}
+                          radius="xl"
+                          variant="filled"
+                        />
+                        <Text size="lg">{user.displayName}</Text>
+                      </Group>
+                    );
+                  } else return null;
+                })}
+              </Stack>
+              <Divider my="md" label="グループID" color="gray" />
+              <Group>
+                <Text size="lg">{groupData.groupId}</Text>
+                <CopyButton value={groupData.groupId}>
+                  {({ copied, copy }) => (
+                    <ActionIcon
+                      size={26}
+                      onClick={copy}
+                      color={copied ? "lime" : "cyan"}
+                    >
+                      {copied ? <IconClipboardCheck /> : <IconClipboard />}
+                    </ActionIcon>
+                  )}
+                </CopyButton>
+              </Group>
+            </Card>
+          </>
+        ) : null}
+      </Stack>
+    </Container>
+  );
+};
+
+export default GroupInformation;

--- a/src/features/group/hooks/useGroupInformation.ts
+++ b/src/features/group/hooks/useGroupInformation.ts
@@ -1,0 +1,34 @@
+import { showNotification } from "@mantine/notifications";
+import { useContext, useEffect, useState } from "react";
+import { FirebaseContext, UserContext } from "../../../contexts";
+import { findGroup } from "../api/find-group";
+import { GroupType } from "../types";
+
+const useGroupInformation = () => {
+  const { user } = useContext(UserContext);
+  const { db } = useContext(FirebaseContext);
+  const [groupData, setGroupData] = useState<GroupType | null>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      if (db && user && user.groupId) {
+        try {
+          const newGroupData = await findGroup(db, user.groupId);
+          setGroupData(newGroupData);
+        } catch (error) {
+          showNotification({
+            message: "グループ情報の取得に失敗しました",
+            color: "red",
+          });
+        }
+      }
+      setIsLoading(false);
+    })();
+  }, []);
+
+  return { groupData, isLoading };
+};
+
+export default useGroupInformation;

--- a/src/features/group/routes/GroupInformationRoute.tsx
+++ b/src/features/group/routes/GroupInformationRoute.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Route, Routes } from "react-router-dom";
+import GroupInformation from "../components/GroupInformation";
+
+export const GroupInformationRoutes = () => {
+  return (
+    <Routes>
+      <Route path="information" element={<GroupInformation />} />
+      <Route path="*" element={<Navigate to="/app/group/information" />} />
+    </Routes>
+  );
+};

--- a/src/routes/private.tsx
+++ b/src/routes/private.tsx
@@ -6,6 +6,7 @@ import { DinnerPlan } from "../features/dinner/components/DinnerPlan";
 import { DinnerPlans } from "../features/dinner/components/DinnerPlans";
 import { DinnerPlansWithCalendar } from "../features/dinner/components/DinnerPlansWithCalendar";
 import { DinnerRoutes } from "../features/dinner/routes/DinnerRoutes";
+import { GroupInformationRoutes } from "../features/group/routes/GroupInformationRoute";
 import UserSettings from "../features/users/components/UserSettings";
 import { UserProfileRoutes } from "../features/users/routes/UserProfileRoutes";
 
@@ -32,6 +33,7 @@ export const privateRoutes = [
       { path: "", element: <Home /> },
       { path: "dinner/*", element: <DinnerRoutes /> },
       { path: "user/*", element: <UserProfileRoutes /> },
+      { path: "group/*", element: <GroupInformationRoutes /> },
       { path: "*", element: <Navigate to="" /> },
     ],
   },


### PR DESCRIPTION
## issue
- #14 

## なぜやるのか
-  グループに誰が所属しているのか見ることが出来ない
-  招待するためのグループIDを知ることができない

## なにをやったのか
- `GroupInformation`コンポーネントの作成（グループ情報ページの作成）
- ルーティングの追加
- Navbarにグループ情報リンクを追加
- `useGroupInformation`フックを作成し、コンポーネントのロジックをフックに分離

## スクリーンショット

![Screenshot 2022-12-28 at 02-48-18 Vite React TS](https://user-images.githubusercontent.com/106266114/209704979-71d1c3aa-48a6-4bc8-9e6a-dadb4d548c56.png)
