### PR TITLE
ログイン状態でもログインフォームが表示されてしまう問題 

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,15 @@
+import { LoadingOverlay } from "@mantine/core";
+
+const Loading = () => {
+  return (
+    <>
+      <LoadingOverlay
+        loaderProps={{ size: "lg", color: "cyan", variant: "dots" }}
+        visible
+        overlayBlur={2}
+      />
+    </>
+  );
+};
+
+export default Loading;

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -14,7 +14,7 @@ export const FirebaseContext = createContext<FirebaseContextValue>({
 });
 
 type UserContextValue = {
-  user: UserType | null;
+  user: UserType | null | undefined;
   setUser: ((user: UserType) => void) | null;
 };
 

--- a/src/providers/FirebaseApp.tsx
+++ b/src/providers/FirebaseApp.tsx
@@ -9,7 +9,7 @@ import { findUser } from "../features/auth/api/find-user";
 import { FirebaseContext, UserContext } from "../contexts";
 
 const FirebaseApp: FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<UserType | null>(null);
+  const [user, setUser] = useState<UserType | null | undefined>(undefined);
   const auth = getAuth(app);
   const db = getFirestore(app);
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,10 +5,12 @@ import { privateRoutes } from "./private";
 import { publicRoutes } from "./public";
 import { profileUndefinedRoutes } from "./profileUndefined";
 import { groupUndefinedRoutes } from "./groupUndefined";
+import { userUndefinedRoutes } from "./userUndefined";
 
 export const AppRoutes = () => {
   const { user } = useContext(UserContext);
   let routes = publicRoutes;
+  if (user === undefined) routes = userUndefinedRoutes;
   if (user) {
     if (!user?.displayName) {
       routes = profileUndefinedRoutes;

--- a/src/routes/userUndefined.tsx
+++ b/src/routes/userUndefined.tsx
@@ -1,0 +1,7 @@
+import Loading from "../components/Loading";
+export const userUndefinedRoutes = [
+  {
+    path: "*",
+    element: <Loading />,
+  },
+];


### PR DESCRIPTION
## issue

- #18 

## なぜやるのか

- ログインしている状態でアクセスした場合に、最初にログインフォームが描画されないようにしたい

## なにをやったのか

- UserContextのuserの型にundefinedを追加
- Loadingコンポーネントの作成
- userがundefinedの時のルーティングを追加（Loadingコンポーネントを描画する）

## 結果
- ログインしている状態でのアクセス時にログインフォームが表示されなくなり、代わりにローディング画面が表示されるように